### PR TITLE
Fixing broken description on theme selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme Name: MapPress
 Theme URI: https://github.com/miguelpeixe/mappress
 Author: Cardume
 Author URI: http://www.cardume.art.br/
-Description: WordPress + MapBox = MapPress
+Description: "WordPress + MapBox = MapPress"
 Version: 0.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
I´m pretty sure the + or = broke the string. 
Without this change, the description was not
showing up, thus the sub-theme could not be installed.
