### PR TITLE
Convert geojson coordinates from strings to numbers

### DIFF
--- a/inc/markers.php
+++ b/inc/markers.php
@@ -142,7 +142,7 @@ class JEO_Markers {
 		wp_register_script('leaflet-markerclusterer', get_template_directory_uri() . '/lib/leaflet/leaflet.markercluster.js', array('jeo'), '0.2');
 		wp_register_style('leaflet-markerclusterer', get_template_directory_uri() . '/lib/leaflet/MarkerCluster.Default.css', array(), '0.2');
 
-		/* 
+		/*
 		 * Clustering
 		 */
 		if($this->use_clustering()) {
@@ -552,7 +552,7 @@ class JEO_Markers {
 		} else {
 			$geometry = array();
 			$geometry['type'] = 'Point';
-			$geometry['coordinates'] = $coordinates;
+			$geometry['coordinates'] = array_map('floatval', $coordinates);
 		}
 		return apply_filters('jeo_marker_geometry', $geometry, $post);
 	}


### PR DESCRIPTION
Currently GeoJSON coordinates have string type, which makes it invalid when entered to [GeoJSONLint](http://geojsonlint.com/).

Note: This code has been applied and tested in [Ekuatorial](http://ekuatorial.com/?ekuatorial_advanced_nav=1&ekuatorial_filter_s&ekuatorial_filter_category%5B0%5D=17&ekuatorial_filter_category%5B1%5D=21&ekuatorial_filter_category%5B2%5D=20&ekuatorial_filter_category%5B3%5D=1&ekuatorial_filter_date_start&ekuatorial_filter_date_end&geojson=1).

Thank you,
Alan.
